### PR TITLE
Update URL builder to support non-root schema registry paths

### DIFF
--- a/sr.go
+++ b/sr.go
@@ -258,7 +258,7 @@ func buildURL(baseURL, path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	u.Path = path
+	u.Path += path
 	return u.String(), nil
 }
 


### PR DESCRIPTION
Currently, sr's URL builder always appends the path to the root of the domain passed by the user. This breaks if the schema registry is running at a non-root path like `http://domain/schema-registry`. This fix changes the URL builder to append the generated path to the base URL provided by the user.